### PR TITLE
[#6] 댓글 좋아요 기능

### DIFF
--- a/src/main/java/org/example/mjuteam4/comment/CommentController.java
+++ b/src/main/java/org/example/mjuteam4/comment/CommentController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/api")
 public class CommentController {
-    private final Long memberId = 9999L; // 임시용 memberId
+    private final Long memberId = 999L; // 임시용 memberId
     private final CommentService commentService;
     @PostMapping("/question/{question_id}/comment")
     public ResponseEntity<CommentResponse> createComment(

--- a/src/main/java/org/example/mjuteam4/comment/CommentController.java
+++ b/src/main/java/org/example/mjuteam4/comment/CommentController.java
@@ -12,10 +12,11 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api")
 public class CommentController {
     private final Long memberId = 9999L; // 임시용 memberId
     private final CommentService commentService;
-    @PostMapping("/api/question/{question_id}/comment")
+    @PostMapping("/question/{question_id}/comment")
     public ResponseEntity<CommentResponse> createComment(
             @PathVariable(value = "question_id") Long questionId,
             @RequestBody CommentRequest commentRequest
@@ -25,7 +26,7 @@ public class CommentController {
         return ResponseEntity.ok().body(commentResponse);
     }
 
-    @GetMapping("/api/question/{question_id}/comments")
+    @GetMapping("/question/{question_id}/comments")
     public Page<CommentResponse> getCommentList(
             @PathVariable(value = "question_id") Long questionId,
             @RequestParam(value = "page", defaultValue = "0") int page,
@@ -36,7 +37,7 @@ public class CommentController {
         return comments.map(CommentResponse::createCommentResponse);
     }
 
-    @PutMapping("/api/comment/{comment_id}")
+    @PutMapping("/comment/{comment_id}")
     public ResponseEntity<CommentResponse> modifyComment(
             @PathVariable(value = "comment_id") Long commentId,
             @RequestBody CommentRequest commentRequest)
@@ -46,7 +47,7 @@ public class CommentController {
         return ResponseEntity.ok().body(commentResponse);
     }
 
-    @DeleteMapping("/api/comment/{comment_id}")
+    @DeleteMapping("/comment/{comment_id}")
     public ResponseEntity<String> deleteComment(@PathVariable(value = "comment_id") Long commentId){
         commentService.deleteComment(memberId, commentId);
         return ResponseEntity.ok().body("comment deleted");

--- a/src/main/java/org/example/mjuteam4/comment/CommentRepository.java
+++ b/src/main/java/org/example/mjuteam4/comment/CommentRepository.java
@@ -1,7 +1,9 @@
 package org.example.mjuteam4.comment;
 
 import org.example.mjuteam4.comment.entity.Comment;
+import org.example.mjuteam4.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
 }

--- a/src/main/java/org/example/mjuteam4/comment/CommentService.java
+++ b/src/main/java/org/example/mjuteam4/comment/CommentService.java
@@ -23,7 +23,7 @@ public class CommentService {
     private final MemberService memberService;
     public Comment commentCreate(Long memberId, Long questionId, CommentRequest commentRequest) {
         Question question = questionService.findQuestionById(questionId);
-        Member member = memberService.findById(memberId);
+        Member member = memberService.findByMemberId(memberId);
 
         Comment comment = Comment.createComment(commentRequest);
         comment.setQuestion(question);
@@ -65,5 +65,10 @@ public class CommentService {
         }
 
         return comment;
+    }
+
+    // 댓글 id로 댓글 조회하기
+    public Comment findByCommentId(Long commentId){
+        return commentRepository.findById(commentId).orElseThrow(CommentNotFound::new);
     }
 }

--- a/src/main/java/org/example/mjuteam4/comment/dto/response/CommentResponse.java
+++ b/src/main/java/org/example/mjuteam4/comment/dto/response/CommentResponse.java
@@ -21,4 +21,5 @@ public class CommentResponse {
     public static CommentResponse createCommentResponse(final Comment comment) {
         return new CommentResponse(comment);
     }
+
 }

--- a/src/main/java/org/example/mjuteam4/comment/entity/Comment.java
+++ b/src/main/java/org/example/mjuteam4/comment/entity/Comment.java
@@ -4,10 +4,13 @@ import jakarta.persistence.*;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.example.mjuteam4.comment.dto.request.CommentRequest;
+import org.example.mjuteam4.commentLike.entity.CommentLike;
 import org.example.mjuteam4.member.entity.Member;
 import org.example.mjuteam4.question.entity.Question;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @NoArgsConstructor
@@ -30,6 +33,9 @@ public class Comment {
     @ManyToOne(fetch = FetchType.LAZY)
     private Question question;
 
+    @OneToMany(mappedBy = "comment", orphanRemoval = true, cascade = CascadeType.ALL)
+    private List<CommentLike> commentLikes = new ArrayList<>();
+
     // 생성자
     private Comment(final CommentRequest commentRequest){
         this.content = commentRequest.getComment();
@@ -51,6 +57,11 @@ public class Comment {
         return this;
     }
 
+    // 댓글 좋아요 수 조회 메서드
+    public int countCommentLike(){
+        return commentLikes.size();
+    }
+
     //의존관계 설정
     public void setQuestion(Question question){
         this.question = question;
@@ -60,5 +71,17 @@ public class Comment {
     public void setMember(Member member){
         this.member = member;
         member.getComments().add(this);
+    }
+
+    public void addCommentLike(CommentLike commentLike){
+        commentLikes.add(commentLike);
+        commentLike.setComment(this);
+    }
+
+    public void removeCommentLike(CommentLike commentLike) {
+        if(commentLikes.contains(commentLike)) {
+            commentLikes.remove(commentLike);
+            commentLike.setComment(null);
+        }
     }
 }

--- a/src/main/java/org/example/mjuteam4/commentLike/CommentLikeController.java
+++ b/src/main/java/org/example/mjuteam4/commentLike/CommentLikeController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.example.mjuteam4.comment.CommentService;
 import org.example.mjuteam4.comment.entity.Comment;
 import org.example.mjuteam4.commentLike.dto.response.CommentLikeResponse;
+import org.example.mjuteam4.commentLike.dto.response.CommentLikeTotalResponse;
 import org.example.mjuteam4.commentLike.entity.CommentLike;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,18 +19,18 @@ public class CommentLikeController {
     private final CommentService commentService;
 
     // 좋아요 완료
-    @PostMapping("/{commentId}/likes")
+    @PostMapping("/{comment-id}/likes")
     public ResponseEntity<CommentLikeResponse> likeUp(
-            @PathVariable(value = "commentId") Long commentId){
+            @PathVariable(value = "comment-id") Long commentId){
         CommentLike commentLike = commentLikeService.increaseLike(memberId, commentId);
         CommentLikeResponse commentLikeResponse = CommentLikeResponse.createWithCommentLike(commentLike, true);
         return ResponseEntity.status(201).body(commentLikeResponse);
     }
 
     // 좋아요 취소
-    @DeleteMapping("/{commentId}/likes")
+    @DeleteMapping("/{comment-id}/likes")
     public ResponseEntity<CommentLikeResponse> likeDown(
-            @PathVariable(value = "commentId") Long commentId)
+            @PathVariable(value = "comment-id") Long commentId)
     {
         commentLikeService.decreaseLike(memberId,commentId);
         Comment comment = commentService.findByCommentId(commentId);
@@ -38,12 +39,13 @@ public class CommentLikeController {
     }
 
     // 총 좋아요 수
-    @GetMapping("/{commentId}/likes/count")
-    public ResponseEntity<Integer> likeCount(
-            @PathVariable(value = "commentId") Long commentId)
+    @GetMapping("/{comment-id}/likes/count")
+    public ResponseEntity<CommentLikeTotalResponse> likeCount(
+            @PathVariable(value = "comment-id") Long commentId)
     {
         Integer totalLike = commentLikeService.getTotalLike(commentId);
-        return ResponseEntity.ok().body(totalLike);
+        CommentLikeTotalResponse response = CommentLikeTotalResponse.builder().totalLikeCount(totalLike).build();
+        return ResponseEntity.ok().body(response);
     }
 
 }

--- a/src/main/java/org/example/mjuteam4/commentLike/CommentLikeController.java
+++ b/src/main/java/org/example/mjuteam4/commentLike/CommentLikeController.java
@@ -1,0 +1,49 @@
+package org.example.mjuteam4.commentLike;
+
+import lombok.RequiredArgsConstructor;
+import org.example.mjuteam4.comment.CommentService;
+import org.example.mjuteam4.comment.entity.Comment;
+import org.example.mjuteam4.commentLike.dto.response.CommentLikeResponse;
+import org.example.mjuteam4.commentLike.entity.CommentLike;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/comments/")
+public class CommentLikeController {
+
+    private final Long memberId = 999L;
+    private final CommentLikeService commentLikeService;
+    private final CommentService commentService;
+
+    // 좋아요 완료
+    @PostMapping("/{commentId}/likes")
+    public ResponseEntity<CommentLikeResponse> likeUp(
+            @PathVariable(value = "commentId") Long commentId){
+        CommentLike commentLike = commentLikeService.increaseLike(memberId, commentId);
+        CommentLikeResponse commentLikeResponse = CommentLikeResponse.createWithCommentLike(commentLike, true);
+        return ResponseEntity.status(201).body(commentLikeResponse);
+    }
+
+    // 좋아요 취소
+    @DeleteMapping("/{commentId}/likes")
+    public ResponseEntity<CommentLikeResponse> likeDown(
+            @PathVariable(value = "commentId") Long commentId)
+    {
+        commentLikeService.decreaseLike(memberId,commentId);
+        Comment comment = commentService.findByCommentId(commentId);
+        CommentLikeResponse commentLikeResponse = CommentLikeResponse.createWithComment(comment, false);
+        return ResponseEntity.ok().body(commentLikeResponse);
+    }
+
+    // 총 좋아요 수
+    @GetMapping("/{commentId}/likes/count")
+    public ResponseEntity<Integer> likeCount(
+            @PathVariable(value = "commentId") Long commentId)
+    {
+        Integer totalLike = commentLikeService.getTotalLike(commentId);
+        return ResponseEntity.ok().body(totalLike);
+    }
+
+}

--- a/src/main/java/org/example/mjuteam4/commentLike/CommentLikeRepository.java
+++ b/src/main/java/org/example/mjuteam4/commentLike/CommentLikeRepository.java
@@ -1,0 +1,16 @@
+package org.example.mjuteam4.commentLike;
+
+
+import org.example.mjuteam4.comment.entity.Comment;
+import org.example.mjuteam4.commentLike.entity.CommentLike;
+import org.example.mjuteam4.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
+    boolean existsByMemberAndComment(Member member, Comment comment);
+
+    CommentLike findByMemberAndComment(Member member, Comment comment);
+
+}

--- a/src/main/java/org/example/mjuteam4/commentLike/CommentLikeService.java
+++ b/src/main/java/org/example/mjuteam4/commentLike/CommentLikeService.java
@@ -1,0 +1,54 @@
+package org.example.mjuteam4.commentLike;
+
+import lombok.RequiredArgsConstructor;
+import org.example.mjuteam4.comment.CommentService;
+import org.example.mjuteam4.comment.entity.Comment;
+import org.example.mjuteam4.commentLike.entity.CommentLike;
+import org.example.mjuteam4.commentLike.exception.AlreadyLikedException;
+import org.example.mjuteam4.member.MemberService;
+import org.example.mjuteam4.member.entity.Member;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CommentLikeService {
+
+    private final CommentLikeRepository commentLikeRepository;
+    private final MemberService memberService;
+    private final CommentService commentService;
+
+    public CommentLike increaseLike(Long memberId, Long commentId) {
+        Member member = memberService.findByMemberId(memberId);
+        Comment comment = commentService.findByCommentId(commentId);
+
+
+        if(commentLikeRepository.existsByMemberAndComment(member, comment)) {
+            throw new AlreadyLikedException();
+        }
+
+        CommentLike commentLike = CommentLike.createCommentLike(member, comment);
+        member.addCommentLike(commentLike);
+        comment.addCommentLike(commentLike);
+        return commentLikeRepository.save(commentLike);
+    }
+
+
+    public void decreaseLike(Long memberId, Long commentId){
+        Member member = memberService.findByMemberId(memberId);
+        Comment comment = commentService.findByCommentId(commentId);
+
+        if(!commentLikeRepository.existsByMemberAndComment(member, comment)) {
+            throw new RuntimeException("좋아요 하지 않은 상태에서 좋아요를 취소할 수는 없음");
+        }
+
+        CommentLike commentLike = commentLikeRepository.findByMemberAndComment(member, comment);
+        comment.removeCommentLike(commentLike);
+        commentLikeRepository.delete(commentLike);
+    }
+
+    public Integer getTotalLike(Long commentId){
+        return commentService.findByCommentId(commentId).countCommentLike();
+    }
+}

--- a/src/main/java/org/example/mjuteam4/commentLike/CommentLikeService.java
+++ b/src/main/java/org/example/mjuteam4/commentLike/CommentLikeService.java
@@ -5,6 +5,7 @@ import org.example.mjuteam4.comment.CommentService;
 import org.example.mjuteam4.comment.entity.Comment;
 import org.example.mjuteam4.commentLike.entity.CommentLike;
 import org.example.mjuteam4.commentLike.exception.AlreadyLikedException;
+import org.example.mjuteam4.commentLike.exception.NotLikedException;
 import org.example.mjuteam4.member.MemberService;
 import org.example.mjuteam4.member.entity.Member;
 import org.springframework.stereotype.Service;
@@ -40,7 +41,7 @@ public class CommentLikeService {
         Comment comment = commentService.findByCommentId(commentId);
 
         if(!commentLikeRepository.existsByMemberAndComment(member, comment)) {
-            throw new RuntimeException("좋아요 하지 않은 상태에서 좋아요를 취소할 수는 없음");
+            throw new NotLikedException();
         }
 
         CommentLike commentLike = commentLikeRepository.findByMemberAndComment(member, comment);

--- a/src/main/java/org/example/mjuteam4/commentLike/dto/response/CommentLikeResponse.java
+++ b/src/main/java/org/example/mjuteam4/commentLike/dto/response/CommentLikeResponse.java
@@ -1,0 +1,36 @@
+package org.example.mjuteam4.commentLike.dto.response;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.example.mjuteam4.comment.entity.Comment;
+import org.example.mjuteam4.commentLike.entity.CommentLike;
+
+@Data
+@NoArgsConstructor
+public class CommentLikeResponse {
+    private Long commentId;
+    private Integer likeCount;
+    private boolean liked;
+
+    private CommentLikeResponse(final CommentLike commentLike, final boolean liked) {
+        Comment comment = commentLike.getComment();
+        this.commentId = comment.getId();
+        this.likeCount = comment.countCommentLike();
+        this.liked = liked;
+    }
+
+    private CommentLikeResponse(final Comment comment, final boolean liked) {
+        this.commentId = comment.getId();
+        this.likeCount = comment.countCommentLike();
+        this.liked = liked;
+    }
+
+    public static CommentLikeResponse createWithCommentLike(final CommentLike commentLike, final boolean liked){
+        return new CommentLikeResponse(commentLike, liked);
+    }
+
+    public static CommentLikeResponse createWithComment(final Comment comment, final boolean liked) {
+        return new CommentLikeResponse(comment, liked);
+    }
+
+}

--- a/src/main/java/org/example/mjuteam4/commentLike/dto/response/CommentLikeTotalResponse.java
+++ b/src/main/java/org/example/mjuteam4/commentLike/dto/response/CommentLikeTotalResponse.java
@@ -1,0 +1,14 @@
+package org.example.mjuteam4.commentLike.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentLikeTotalResponse {
+    private Integer totalLikeCount;
+}

--- a/src/main/java/org/example/mjuteam4/commentLike/entity/CommentLike.java
+++ b/src/main/java/org/example/mjuteam4/commentLike/entity/CommentLike.java
@@ -1,0 +1,33 @@
+package org.example.mjuteam4.commentLike.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.*;
+import org.example.mjuteam4.comment.entity.Comment;
+import org.example.mjuteam4.global.domain.LikeBaseEntity;
+import org.example.mjuteam4.member.entity.Member;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@Entity
+@Setter
+@Getter
+public class CommentLike extends LikeBaseEntity {
+    @JoinColumn(name = "comment_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Comment comment;
+
+    private CommentLike(final Member member, final Comment comment) {
+        this.member = member;
+        this.comment = comment;
+        this.likedAt = LocalDateTime.now();
+    }
+
+    public static CommentLike createCommentLike(final Member member, final Comment comment){
+        return new CommentLike(member,comment);
+    }
+
+}

--- a/src/main/java/org/example/mjuteam4/commentLike/exception/AlreadyLikedException.java
+++ b/src/main/java/org/example/mjuteam4/commentLike/exception/AlreadyLikedException.java
@@ -1,0 +1,10 @@
+package org.example.mjuteam4.commentLike.exception;
+
+import org.example.mjuteam4.global.exception.ExceptionCode;
+import org.example.mjuteam4.global.exception.GlobalException;
+
+public class AlreadyLikedException extends GlobalException {
+    public AlreadyLikedException() {
+        super(ExceptionCode.ALREADY_LIKED_EXCEPTION);
+    }
+}

--- a/src/main/java/org/example/mjuteam4/commentLike/exception/NotLikedException.java
+++ b/src/main/java/org/example/mjuteam4/commentLike/exception/NotLikedException.java
@@ -1,0 +1,10 @@
+package org.example.mjuteam4.commentLike.exception;
+
+import org.example.mjuteam4.global.exception.ExceptionCode;
+import org.example.mjuteam4.global.exception.GlobalException;
+
+public class NotLikedException extends GlobalException {
+    public NotLikedException() {
+        super(ExceptionCode.NOT_LIKED_YET_EXCEPTION);
+    }
+}

--- a/src/main/java/org/example/mjuteam4/global/domain/LikeBaseEntity.java
+++ b/src/main/java/org/example/mjuteam4/global/domain/LikeBaseEntity.java
@@ -1,0 +1,20 @@
+package org.example.mjuteam4.global.domain;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import org.example.mjuteam4.member.entity.Member;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Data
+public abstract class LikeBaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "member_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    protected Member member;
+    protected LocalDateTime likedAt;
+}

--- a/src/main/java/org/example/mjuteam4/global/exception/ExceptionCode.java
+++ b/src/main/java/org/example/mjuteam4/global/exception/ExceptionCode.java
@@ -18,7 +18,11 @@ public enum ExceptionCode {
 
     //commentLike
     ALREADY_LIKED_EXCEPTION(409,"ALREADY_LIKED_EXCEPTION", "이미 좋아요를 누른 상태에서 다시 좋아요르 누를 수는 없습니다."),
-    NOT_LIKED_YET_EXCEPTION(400, "NOT_LIKE_YEY_EXCEPTION","좋아요를 누르지 않은 상태에서 좋아요를 취소할 수는 없습니다.");
+    NOT_LIKED_YET_EXCEPTION(400, "NOT_LIKE_YET_EXCEPTION","좋아요를 누르지 않은 상태에서 좋아요를 취소할 수는 없습니다."),
+
+
+    //tradePost
+    TRADE_POST_NOT_FOUND(404,"TRADE_POST_NOT_FOUND","해당 거래 게시글을 찾을 수 없습니다"),
     ;
 
 

--- a/src/main/java/org/example/mjuteam4/global/exception/ExceptionCode.java
+++ b/src/main/java/org/example/mjuteam4/global/exception/ExceptionCode.java
@@ -14,7 +14,11 @@ public enum ExceptionCode {
 
     //comment
     COMMENT_NOT_FOUND(404,"COMMENT_NOT_FOUND","댓글을 찾을 수 없습니다"),
-    COMMENT_UNAUTHORIZED_EXCEPTION(403, "COMMENT_UNAUTHORIZED_EXCEPTION", "댓글을 수정할 수 있는 권한이 없습니다.")
+    COMMENT_UNAUTHORIZED_EXCEPTION(403, "COMMENT_UNAUTHORIZED_EXCEPTION", "댓글을 수정할 수 있는 권한이 없습니다."),
+
+    //commentLike
+    ALREADY_LIKED_EXCEPTION(409,"ALREADY_LIKED_EXCEPTION", "이미 좋아요를 누른 상태에서 다시 좋아요르 누를 수는 없습니다."),
+    NOT_LIKED_YET_EXCEPTION(400, "NOT_LIKE_YEY_EXCEPTION","좋아요를 누르지 않은 상태에서 좋아요를 취소할 수는 없습니다.");
     ;
 
 

--- a/src/main/java/org/example/mjuteam4/member/MemberService.java
+++ b/src/main/java/org/example/mjuteam4/member/MemberService.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service;
 public class MemberService {
     private final MemberRepository memberRepository;
 
-    public Member findById(Long memberId) {
+    public Member findByMemberId(Long memberId) {
         // 질문 게시판 작성한 임시 코드 -> 예외 처리 필요
         return memberRepository.findById(memberId).get();
     }

--- a/src/main/java/org/example/mjuteam4/member/entity/Member.java
+++ b/src/main/java/org/example/mjuteam4/member/entity/Member.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 import org.example.mjuteam4.comment.entity.Comment;
 import org.example.mjuteam4.commentLike.entity.CommentLike;
 import org.example.mjuteam4.question.entity.Question;
+import org.example.mjuteam4.tradePost.entity.TradePost;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +29,9 @@ public class Member {
     @OneToMany(mappedBy = "member", orphanRemoval = true, cascade = CascadeType.ALL)
     public List<CommentLike> commentLikes = new ArrayList<>();
 
+    @OneToMany(mappedBy = "member", orphanRemoval = true, cascade = CascadeType.ALL)
+    public List<TradePost> tradePosts = new ArrayList<>();
+
     // 연관관계 편의 메서드
     public void addQuestion(Question question) {
         questions.add(question);
@@ -37,5 +41,10 @@ public class Member {
     public void addCommentLike(CommentLike commentLike){
         commentLikes.add(commentLike);
         commentLike.setMember(this);
+    }
+
+    public void addTradePost(TradePost tradePost){
+        tradePosts.add(tradePost);
+        tradePost.setMember(this);
     }
 }

--- a/src/main/java/org/example/mjuteam4/member/entity/Member.java
+++ b/src/main/java/org/example/mjuteam4/member/entity/Member.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.example.mjuteam4.comment.entity.Comment;
+import org.example.mjuteam4.commentLike.entity.CommentLike;
 import org.example.mjuteam4.question.entity.Question;
 
 import java.util.ArrayList;
@@ -24,9 +25,17 @@ public class Member {
     @OneToMany(mappedBy = "member", orphanRemoval = true, cascade = CascadeType.ALL)
     public List<Comment> comments = new ArrayList<>();
 
+    @OneToMany(mappedBy = "member", orphanRemoval = true, cascade = CascadeType.ALL)
+    public List<CommentLike> commentLikes = new ArrayList<>();
+
     // 연관관계 편의 메서드
     public void addQuestion(Question question) {
         questions.add(question);
         question.setMember(this);
+    }
+
+    public void addCommentLike(CommentLike commentLike){
+        commentLikes.add(commentLike);
+        commentLike.setMember(this);
     }
 }

--- a/src/main/java/org/example/mjuteam4/question/QuestionService.java
+++ b/src/main/java/org/example/mjuteam4/question/QuestionService.java
@@ -31,7 +31,7 @@ public class QuestionService {
         Question question = Question.createQuestion(questionRequest);
         QuestionImage questionImage = questionImageService.createQuestionImage(questionRequest.getImage());
         question.setQuestionImage(questionImage);
-        Member member = memberService.findById(memberId);
+        Member member = memberService.findByMemberId(memberId);
         member.addQuestion(question);
         return questionRepository.save(question);
     }

--- a/src/main/java/org/example/mjuteam4/tradePost/TradePostController.java
+++ b/src/main/java/org/example/mjuteam4/tradePost/TradePostController.java
@@ -1,0 +1,63 @@
+package org.example.mjuteam4.tradePost;
+
+import lombok.RequiredArgsConstructor;
+import org.example.mjuteam4.tradePost.dto.request.TradePostRequest;
+import org.example.mjuteam4.tradePost.dto.response.TradePostResponse;
+import org.example.mjuteam4.tradePost.entity.TradePost;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/trade")
+public class TradePostController {
+    private final TradePostService tradePostService;
+
+    @PostMapping("/create")
+    public ResponseEntity<TradePostResponse> tradePostCreate(@ModelAttribute TradePostRequest tradePostRequest) {
+        Long memberId = 999L;
+        TradePost tradePost = tradePostService.createTradePost(memberId, tradePostRequest);
+        TradePostResponse tradePostResponse = TradePostResponse.create(tradePost);
+        return ResponseEntity.ok().body(tradePostResponse);
+    }
+
+    @GetMapping("/all")
+    public ResponseEntity<Page<TradePostResponse>> tradePostList(
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size)
+    {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<TradePost> tradePosts = tradePostService.tradePostList(pageable);
+        Page<TradePostResponse> response = tradePosts.map(TradePostResponse::create);
+        return ResponseEntity.ok().body(response);
+    }
+
+    @GetMapping("/{trade-post-id}")
+    public ResponseEntity<TradePostResponse> tradePostDetail(@PathVariable(value = "trade-post-id") Long questionId) {
+        TradePost tradePost = tradePostService.tradePostDetail(questionId);
+        TradePostResponse tradePostResponse = TradePostResponse.create(tradePost);
+        return ResponseEntity.ok().body(tradePostResponse);
+    }
+
+    @PutMapping("/{trade-post-id}")
+    public ResponseEntity<TradePostResponse> questionModify(
+            @PathVariable(value = "trade-post-id") Long tradePostId,
+            @ModelAttribute TradePostRequest tradePostRequest
+    ) {
+        TradePost tradePost = tradePostService.modifyTradePost(tradePostId, tradePostRequest);
+        TradePostResponse tradePostResponse = TradePostResponse.create(tradePost);
+        return ResponseEntity.ok().body(tradePostResponse);
+    }
+
+    @DeleteMapping("/{trade-post-id}")
+    public ResponseEntity<String> questionDelete(
+            @PathVariable(value = "trade-post-id") Long tradePostId)
+    {
+        tradePostService.deleteTradePost(tradePostId);
+        return ResponseEntity.ok().body("Deleted Success");
+    }
+
+}

--- a/src/main/java/org/example/mjuteam4/tradePost/TradePostRepository.java
+++ b/src/main/java/org/example/mjuteam4/tradePost/TradePostRepository.java
@@ -1,0 +1,7 @@
+package org.example.mjuteam4.tradePost;
+
+import org.example.mjuteam4.tradePost.entity.TradePost;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TradePostRepository extends JpaRepository<TradePost, Long> {
+}

--- a/src/main/java/org/example/mjuteam4/tradePost/TradePostService.java
+++ b/src/main/java/org/example/mjuteam4/tradePost/TradePostService.java
@@ -1,0 +1,82 @@
+package org.example.mjuteam4.tradePost;
+
+import lombok.RequiredArgsConstructor;
+import org.example.mjuteam4.member.MemberService;
+import org.example.mjuteam4.member.entity.Member;
+import org.example.mjuteam4.question.entity.Question;
+import org.example.mjuteam4.question.exception.QuestionNotFound;
+import org.example.mjuteam4.questionImage.entity.QuestionImage;
+import org.example.mjuteam4.storage.StorageService;
+import org.example.mjuteam4.tradePost.dto.request.TradePostRequest;
+import org.example.mjuteam4.tradePost.entity.TradePost;
+import org.example.mjuteam4.tradePost.exception.TradePostNotFound;
+import org.example.mjuteam4.tradePostImage.TradePostImageService;
+import org.example.mjuteam4.tradePostImage.entity.TradePostImage;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TradePostService {
+    private final TradePostRepository tradePostRepository;
+    private final TradePostImageService tradePostImageService;
+    private final MemberService memberService;
+    private final StorageService storageService;
+
+    public TradePost createTradePost(Long memberId, TradePostRequest tradePostRequest) {
+        TradePost tradePost = TradePost.create(tradePostRequest);
+        TradePostImage tradePostImage = tradePostImageService.createTradePostImage(tradePostRequest.getImage());
+        tradePost.addTradePostImage(tradePostImage);
+        Member member = memberService.findByMemberId(memberId);
+        member.addTradePost(tradePost);
+        return tradePostRepository.save(tradePost);
+    }
+
+    public Page<TradePost> tradePostList(Pageable pageable) {
+        return tradePostRepository.findAll(pageable);
+    }
+
+    public TradePost tradePostDetail(Long tradePostId) {
+        return tradePostRepository.findById(tradePostId).orElseThrow(TradePostNotFound::new);
+    }
+
+    public TradePost modifyTradePost(Long tradePostId, TradePostRequest tradePostRequest) {
+        // 수정 대상 질문 조회 후 제목, 내용 수정
+        TradePost modifiedTradePost = tradePostRepository.findById(tradePostId).orElseThrow(TradePostNotFound::new).modifyTradePost(tradePostRequest);
+        // 이미지 수정
+        // 이미지 변경 요청이 있다면, 기존 s3이미지 삭제하고 새로운 이미지 업로드
+        MultipartFile requestedImage = tradePostRequest.getImage();
+        if(requestedImage != null && !requestedImage.isEmpty()){
+
+            String originalImageUrl = modifiedTradePost.getTradePostImage().getImageUrl();
+            tradePostImageService.deleteImageService(originalImageUrl);
+
+            TradePostImage tradePostImage = tradePostImageService.createTradePostImage(requestedImage);
+
+            modifiedTradePost.setTradePostImage(tradePostImage);
+        }
+
+        return modifiedTradePost;
+    }
+
+    public void deleteTradePost(Long tradePostId) {
+        // 1. s3 버킷에 있는 이미지 우선 삭제
+        TradePost tradePost = tradePostRepository.findById(tradePostId).orElseThrow(TradePostNotFound::new);
+        String imageUrl = tradePost.getTradePostImage().getImageUrl();
+        tradePostImageService.deleteImageService(imageUrl);
+
+        // 2. db row 삭제
+        tradePostRepository.deleteById(tradePostId);
+    }
+
+    public TradePost findTradePostById(Long tradePostId) {
+        return tradePostRepository.findById(tradePostId).orElseThrow(TradePostNotFound::new);
+    }
+
+}

--- a/src/main/java/org/example/mjuteam4/tradePost/dto/request/TradePostRequest.java
+++ b/src/main/java/org/example/mjuteam4/tradePost/dto/request/TradePostRequest.java
@@ -1,0 +1,14 @@
+package org.example.mjuteam4.tradePost.dto.request;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+@Data
+@NoArgsConstructor
+public class TradePostRequest {
+    private String itemName;
+    private Long price;
+    private String description;
+    private MultipartFile image;
+}

--- a/src/main/java/org/example/mjuteam4/tradePost/dto/response/TradePostResponse.java
+++ b/src/main/java/org/example/mjuteam4/tradePost/dto/response/TradePostResponse.java
@@ -1,0 +1,28 @@
+package org.example.mjuteam4.tradePost.dto.response;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.example.mjuteam4.tradePost.entity.TradePost;
+import org.springframework.web.multipart.MultipartFile;
+
+@Data
+@NoArgsConstructor
+public class TradePostResponse {
+    private Long tradePostId;
+    private String itemName;
+    private Long price;
+    private String description;
+    private String imageUrl;
+
+    private TradePostResponse(TradePost tradePost){
+        this.tradePostId = tradePost.getId();
+        this.itemName = tradePost.getItemName();
+        this.price = tradePost.getPrice();
+        this.description = tradePost.getDescription();
+        this.imageUrl = tradePost.getTradePostImage().getImageUrl();
+    }
+
+    public static TradePostResponse create(TradePost tradePost){
+        return new TradePostResponse(tradePost);
+    }
+}

--- a/src/main/java/org/example/mjuteam4/tradePost/entity/TradePost.java
+++ b/src/main/java/org/example/mjuteam4/tradePost/entity/TradePost.java
@@ -1,0 +1,79 @@
+package org.example.mjuteam4.tradePost.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.example.mjuteam4.member.entity.Member;
+import org.example.mjuteam4.question.dto.request.QuestionRequest;
+import org.example.mjuteam4.question.entity.Question;
+import org.example.mjuteam4.tradePost.dto.request.TradePostRequest;
+import org.example.mjuteam4.tradePostImage.entity.TradePostImage;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@NoArgsConstructor
+public class TradePost {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "trade_post_id")
+    private Long id;
+
+    private Long price;
+    private String description;
+    private String itemName;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @JoinColumn(name = "member_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @OneToOne(mappedBy = "tradePost", orphanRemoval = true, cascade = CascadeType.ALL)
+    private TradePostImage tradePostImage;
+
+    // 생성자
+    private TradePost(TradePostRequest tradePostRequest){
+        this.price = tradePostRequest.getPrice();
+        this.description = tradePostRequest.getDescription();
+        this.itemName = tradePostRequest.getItemName();
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    // 생성 메서드
+    public static TradePost create(TradePostRequest tradePostRequest){
+        return new TradePost(tradePostRequest);
+    }
+
+    // 수정 메서드
+    public TradePost modifyTradePost(TradePostRequest tradePostRequest) {
+        String itemName = tradePostRequest.getItemName();
+        String description = tradePostRequest.getDescription();
+        Long price = tradePostRequest.getPrice();
+
+        if(StringUtils.hasText(itemName)){
+            this.itemName = itemName;
+        }
+        if(StringUtils.hasText(TradePost.this.description)) {
+            this.description = description;
+        }
+
+        if (price != null && price > 0) {
+            this.price = price;
+        }
+
+        this.updatedAt = LocalDateTime.now();
+        return this;
+    }
+
+
+    // 의존관계 메서드
+    public void addTradePostImage(TradePostImage tradePostImage){
+        this.tradePostImage = tradePostImage;
+        tradePostImage.setTradePost(this);
+    }
+}

--- a/src/main/java/org/example/mjuteam4/tradePost/exception/TradePostNotFound.java
+++ b/src/main/java/org/example/mjuteam4/tradePost/exception/TradePostNotFound.java
@@ -1,0 +1,11 @@
+package org.example.mjuteam4.tradePost.exception;
+
+import org.example.mjuteam4.global.exception.ExceptionCode;
+import org.example.mjuteam4.global.exception.GlobalException;
+
+public class TradePostNotFound extends GlobalException {
+
+    public TradePostNotFound() {
+        super(ExceptionCode.TRADE_POST_NOT_FOUND);
+    }
+}

--- a/src/main/java/org/example/mjuteam4/tradePostImage/TradePostImageRepository.java
+++ b/src/main/java/org/example/mjuteam4/tradePostImage/TradePostImageRepository.java
@@ -1,0 +1,9 @@
+package org.example.mjuteam4.tradePostImage;
+
+import org.example.mjuteam4.tradePostImage.entity.TradePostImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TradePostImageRepository extends JpaRepository<TradePostImage, Long> {
+}

--- a/src/main/java/org/example/mjuteam4/tradePostImage/TradePostImageService.java
+++ b/src/main/java/org/example/mjuteam4/tradePostImage/TradePostImageService.java
@@ -1,0 +1,23 @@
+package org.example.mjuteam4.tradePostImage;
+
+import lombok.RequiredArgsConstructor;
+import org.example.mjuteam4.storage.StorageService;
+import org.example.mjuteam4.tradePostImage.entity.TradePostImage;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class TradePostImageService {
+    private final StorageService storageService;
+
+    public TradePostImage createTradePostImage(MultipartFile multipartFile){
+        String s3ImageUrl = storageService.uploadFile(multipartFile, "tradePostImage", 5L);
+        TradePostImage tradePostImage = TradePostImage.createTradePostImage(s3ImageUrl);
+        return tradePostImage;
+    }
+
+    public void deleteImageService(String originalImageUrl){
+        storageService.deleteFile(originalImageUrl);
+    }
+}

--- a/src/main/java/org/example/mjuteam4/tradePostImage/entity/TradePostImage.java
+++ b/src/main/java/org/example/mjuteam4/tradePostImage/entity/TradePostImage.java
@@ -1,0 +1,36 @@
+package org.example.mjuteam4.tradePostImage.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.example.mjuteam4.tradePost.entity.TradePost;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor
+@Data
+public class TradePostImage {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "trade_post_image_id")
+    private Long id;
+
+    private String imageUrl;
+    private LocalDateTime uploadedAt;
+
+    @JoinColumn(name = "trade_post_id")
+    @OneToOne(fetch = FetchType.LAZY)
+    private TradePost tradePost;
+
+    // 생성자
+    private TradePostImage(String imageUrl) {
+        this.uploadedAt = LocalDateTime.now();
+        this.imageUrl = imageUrl;
+    }
+
+    // 생성 메서드
+    public static TradePostImage createTradePostImage(String imageUrl) {
+        return new TradePostImage(imageUrl);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#6 

## 📝PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝작업 내용
- 질문 게시판에 달리는 댓글의 좋아요 기능을 추가 했습니다. (좋아요 하기, 좋아요 취소하기, 좋아요 개수 조회하기)
- 좋아요 기능 관련 예외를 생성했습니다
- CommentController의 클래스 레벨에 "/api" 경로가 매핑되도록 변경 했습니다. 세부 경로는 메서드 레벨에서 매핑됩니다.

## 💬리뷰 요구사항(선택)
좋아요 API의 응답 DTO인 CommentLikeResponse에 대해 리뷰 부탁드립니다. 저는 CommentLikeResponse에 commentId, likeCount, liked(좋아요 여부) 정보를 포함했습니다. 이유는 다음과 같습니다.

1. FE에서 좋아요 버튼을 누른 후, 별도로 총 좋아요 수를 조회하는 API를 다시 호출하지 않아도 되도록 likeCount를 응답에 포함시켰습니다.

2. FE에서 이미 좋아요를 눌렀다면 다시 누를 수 없게 하고, 누르지 않았다면 좋아요 버튼을 활성화할 수 있도록 사용자가 해당 댓글에 좋아요를 눌렀는지 여부를 나타내는 liked 값을 응답 DTO에 포함 시켰습니다.